### PR TITLE
pass in bandwidth argument to GetNeighborInfo

### DIFF
--- a/R/CELESTA_functions.R
+++ b/R/CELESTA_functions.R
@@ -221,7 +221,8 @@ CreateCelestaObject <- function(project_title,
   }
   c(nb_list, all_cell_nb_in_bandwidth, cell_nb_dist) %<-% GetNeighborInfo(
     celesta_obj@coords,
-    number_of_neighbors
+    number_of_neighbors,
+    bandwidth
   )
   celesta_obj@nb_list <- nb_list
   celesta_obj@cell_nb_in_bandwidth <- all_cell_nb_in_bandwidth


### PR DESCRIPTION
Hi @weiruo16 @tassicalim ,
Currently the functions 
`CreateCelestaObject` and `GetNeighborInfo` have a "bandwidth" distance argument used in nearest neighbors calculation.

But this "bandwidth" parameter is always taking the default=100, because it's not being passed into GetNeighborInfo.

Here is a proposed fix.  thanks for your work!

cc: @dnadave @NicoleEO

