### PR TITLE
Fix bug related to subsetting columns from dataframe

### DIFF
--- a/R/CELESTA_functions.R
+++ b/R/CELESTA_functions.R
@@ -1580,7 +1580,7 @@ CalculateScores <- function(marker_exp_prob,
     current_scoring_matrix[unassigned_cells, cell_type_num] <- x/sum(x)
   }else{
     current_scoring_matrix[unassigned_cells, cell_type_num] <- t(apply(
-      current_scoring_matrix[unassigned_cells, cell_type_num],
+      current_scoring_matrix[unassigned_cells, cell_type_num, drop = FALSE],
       1, function(x) x / sum(x)
     ))
   }
@@ -1667,8 +1667,8 @@ AssignCellTypes <- function(initial_pri_matrix,
       unassigned_cells
     )
   }else{
-    max.prob_index <- apply(cell_prob_list[unassigned_cells, ], 1, which.max)
-    max.prob <- apply(cell_prob_list[unassigned_cells, ], 1, max)
+    max.prob_index <- apply(cell_prob_list[unassigned_cells, , drop = FALSE], 1, which.max)
+    max.prob <- apply(cell_prob_list[unassigned_cells, , drop = FALSE], 1, max)
     min_prob_diff <- CalculateProbabilityDifference(
       max.prob,
       max.prob_index,
@@ -1900,7 +1900,7 @@ CalculateIndexCellProb <- function(current_cell_prob,
                                    round) {
   # This function uses mean field estimation to calculate the probability
   # For each cell, a probability is calculated for each cell type to check
-  current_cell_prob_list <- current_cell_prob[, cell_type_num]
+  current_cell_prob_list <- current_cell_prob[, cell_type_num, drop = FALSE]
 
   # all cells * cell_type_num
   u <- current_cell_prob_list

--- a/R/CELESTA_functions.R
+++ b/R/CELESTA_functions.R
@@ -1654,7 +1654,7 @@ AssignCellTypes <- function(initial_pri_matrix,
                             low_marker_threshold,
                             min_difference = 0,
                             min_prob = 0) {
-  cell_prob_list <- current_cell_prob[, cell_type_num]
+  cell_prob_list <- current_cell_prob[, cell_type_num, drop = FALSE]
   cell_type_assignment <- current_cell_type_assignment[, round]
   
   if(length(unassigned_cells)<2){


### PR DESCRIPTION
With current code, whenever a single cell type column is subset from the `current_cell_prob` data frame, the result is no longer a data frame. This leads to `incorrect number of dimensions` error downstream during `which.max`. 

To replicate, have only one cell type on a level in the nested lineage hierarchy. E.g. `FOXP3+ T cell`
```csv
cell_types | Lineage_level
-- | --
Stroma | 1_0_1
Tumor | 1_0_2
pDC | 2_0_3
Macrophage | 2_0_4
Neutrophil | 2_0_5
CD4+ T cell | 2_0_6
CD8+ T cell | 2_0_7
B cell | 2_0_8
FOXP3+ T cell | 3_6_9
```